### PR TITLE
version 5.19.1

### DIFF
--- a/dependabot/Gopkg.toml
+++ b/dependabot/Gopkg.toml
@@ -1,3 +1,3 @@
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  version = "v5.17.3"
+  version = "v5.19.1"


### PR DESCRIPTION
I'm not sure, if I'm doing this right. Somehow, the `dependabot` is not detecting new mattermost-releases anymore...
Would be great, if you could fix this, I'm relying on your repository :) 
Many thanks!