### PR TITLE
Upgrade to 5.38.0

### DIFF
--- a/dependabot/go.mod
+++ b/dependabot/go.mod
@@ -1,3 +1,3 @@
 module github.com/SmartHoneybee/ubiquitous-memory/dependabot
 
-require github.com/mattermost/mattermost-server/v5 v5.37.1
+require github.com/mattermost/mattermost-server/v5 v5.38.0


### PR DESCRIPTION
➡️ Mattermost [changelog for 5.38.0](https://docs.mattermost.com/install/self-managed-changelog.html#release-v5-38-feature-release).