### PR TITLE
Update Mattermost to v6.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set environment from runtime properties
         run: |
           echo "MATTERMOST_RELEASE=$(grep 'mattermost-server' dependabot/go.mod | cut -d' ' -f2)" >> $GITHUB_ENV
-          echo "MMCTL_RELEASE=$MATTERMOST_RELEASE" >> $GITHUB_ENV
+          echo "MMCTL_RELEASE=$(grep 'mmctl' dependabot/go.mod | cut -d' ' -f2)" >> $GITHUB_ENV
 
       - name: Pull docker image
         run: 'docker pull "${{ env.DOCKER_IMAGE }}"'

--- a/dependabot/go.mod
+++ b/dependabot/go.mod
@@ -3,6 +3,6 @@ module github.com/SmartHoneybee/ubiquitous-memory/dependabot
 go 1.16
 
 require (
-	github.com/mattermost/mattermost-server/v6 v6.3.0
-	github.com/mattermost/mmctl v0.0.0-20211221153052-1bb2fec4c15e
+	github.com/mattermost/mattermost-server/v6 v6.3.1
+	github.com/mattermost/mmctl v6.3.0
 )


### PR DESCRIPTION
Build logs show that MMCTL_RELEASE has been empty, so I don't think assigning it to $MATTERMOST_RELEASE is working. This is an attempt to use the matching mmctl tag to see how it works. It looks like mmctl gets tagged/versioned very differently from Mattermost server, so this could end up being problematic if Dependabot starts opening PRs. We shall see.