### PR TITLE
Update Mattermost to v6.3.2

### DIFF
--- a/dependabot/go.mod
+++ b/dependabot/go.mod
@@ -3,6 +3,5 @@ module github.com/SmartHoneybee/ubiquitous-memory/dependabot
 go 1.16
 
 require (
-	github.com/mattermost/mattermost-server/v6 v6.3.1
-	github.com/mattermost/mmctl v6.3.0
+	github.com/mattermost/mattermost-server/v6 v6.3.2
 )


### PR DESCRIPTION
This also removes the mmctl entry since it's not versioned correctly for modules.