### PR TITLE
Update default Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   DEBIAN_RELEASE: buster
   DOCKER_PWD: /root
   DOCKER_IMAGE: debian:${DEBIAN_RELEASE}
-  GO_VERSION: 1.16.7
+  GO_VERSION: 1.18.1
 
 jobs:
   build:

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ MMCTL_RELEASE="${MMCTL_RELEASE:-v5.26.0}"
 NODE_KEY="${NODE_KEY:-9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280}"
 NODE_RELEASE="${NODE_RELEASE:-15}"
 # golang version
-GO_VERSION="${GO_VERSION:-1.16.7}"
+GO_VERSION="${GO_VERSION:-1.18.1}"
 
 if [ "$(id -u)" -eq 0 ]; then # as root user
 	# create build user, if needed

--- a/dependabot/go.mod
+++ b/dependabot/go.mod
@@ -1,6 +1,6 @@
 module github.com/SmartHoneybee/ubiquitous-memory/dependabot
 
-go 1.16
+go 1.18
 
 require (
 	github.com/mattermost/mattermost-server/v6 v6.7.0


### PR DESCRIPTION
Mattermost v6.7.0 official release is built with Go 1.18.1. We should stay with them as much as possible.