### PR TITLE
Update to v7.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set environment from runtime properties
         run: |
           echo "MATTERMOST_RELEASE=$(grep 'mattermost-server' dependabot/go.mod | cut -d' ' -f2)" >> $GITHUB_ENV
-          echo "MMCTL_RELEASE=v7.4.0" >> $GITHUB_ENV
+          echo "MMCTL_RELEASE=v7.5.2" >> $GITHUB_ENV
 
       - name: Pull docker image
         run: 'docker pull "${{ env.DOCKER_IMAGE }}"'

--- a/dependabot/go.mod
+++ b/dependabot/go.mod
@@ -3,6 +3,6 @@ module github.com/SmartHoneybee/ubiquitous-memory/dependabot
 go 1.18
 
 require (
-	github.com/mattermost/mattermost-server/v6 v7.4.0
+	github.com/mattermost/mattermost-server/v6 v7.5.2
 	github.com/mattermost/mmctl v0.0.0-20211221153052-1bb2fec4c15e
 )


### PR DESCRIPTION
It looks like 7.5.2 dropped the Boards requirement that was part of the build script in 7.5.1, so I guess we get a reprieve from having to worry about it for now.